### PR TITLE
Improve terrain collisions and player model loading

### DIFF
--- a/game/client/src/assets/AssetLoader.ts
+++ b/game/client/src/assets/AssetLoader.ts
@@ -149,22 +149,46 @@ async function loadFBXTemplate(scene: Scene, url: string): Promise<AssetContaine
 
 async function loadMaxTemplate(scene: Scene, url: string): Promise<AssetContainer> {
   const { directory, baseName } = splitPath(url);
-  maxLoader.setResourcePath(directory);
-  maxLoader.setPath(directory);
-  try {
-    const object = await maxLoader.loadAsync(url);
+  const directories = getCandidateDirectories(directory);
 
-    const textures = await prepareTextures(directory, baseName);
-    applyMaterials(object, textures);
-    normalizeModel(object);
-
-    const glb = await exportToGlb(object, []);
-    const container = await SceneLoader.LoadAssetContainerAsync("data:", glb, scene, undefined, ".glb");
-    return container;
-  } catch (error) {
-    logger.warn(`Импорт .max не удался, пробуем резервный GLB для ${baseName}`, error);
-    return loadGlbFallback(scene, directory, baseName);
+  const glbContainer = await tryLoadGlbCandidates(scene, directories, baseName);
+  if (glbContainer) {
+    return glbContainer;
   }
+
+  const fbxContainer = await tryLoadFbxCandidates(scene, directories, baseName);
+  if (fbxContainer) {
+    return fbxContainer;
+  }
+
+  let lastError: unknown = null;
+  const maxCandidates = createCandidateUrls(directories, baseName, [".max"]);
+  for (const candidate of maxCandidates) {
+    const { directory: candidateDir, baseName: candidateBase } = splitPath(candidate);
+    maxLoader.setResourcePath(candidateDir);
+    maxLoader.setPath(candidateDir);
+    try {
+      const object = await maxLoader.loadAsync(candidate);
+
+      const textures = await prepareTextures(candidateDir, candidateBase);
+      applyMaterials(object, textures);
+      normalizeModel(object);
+
+      const glb = await exportToGlb(object, []);
+      const container = await SceneLoader.LoadAssetContainerAsync("data:", glb, scene, undefined, ".glb");
+      return container;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError) {
+    logger.warn(`Импорт .max не удался, пробуем резервный GLB для ${baseName}`, lastError);
+  } else {
+    logger.warn(`Файл .max для ${baseName} не найден, пробуем резервный GLB`);
+  }
+
+  return loadGlbFallback(scene, directories, baseName);
 }
 
 function splitPath(url: string): { directory: string; baseName: string } {
@@ -337,10 +361,122 @@ async function exportToGlb(object: Object3D, animations: AnimationClip[]): Promi
   });
 }
 
-async function loadGlbFallback(scene: Scene, directory: string, baseName: string): Promise<AssetContainer> {
-  const fallbackUrl = `${directory}${baseName}.glb`;
-  const { rootUrl, fileName } = splitUrl(fallbackUrl);
-  return SceneLoader.LoadAssetContainerAsync(rootUrl, fileName, scene);
+async function loadGlbFallback(scene: Scene, directories: string[], baseName: string): Promise<AssetContainer> {
+  const candidates = createCandidateUrls(directories, baseName, [".glb"]);
+  let lastError: unknown = null;
+  for (const candidate of candidates) {
+    try {
+      const { rootUrl, fileName } = splitUrl(candidate);
+      return await SceneLoader.LoadAssetContainerAsync(rootUrl, fileName, scene);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error(`Не удалось загрузить резервный GLB ${baseName}`);
+}
+
+function getCandidateDirectories(directory: string): string[] {
+  const directories = new Set<string>();
+  const variants = new Set<string>();
+
+  const normalized = normalizeDirectory(directory);
+  variants.add(normalized);
+
+  if (typeof window !== "undefined") {
+    try {
+      const base = document.baseURI ?? window.location.href;
+      const absolute = new URL(directory || "./", base).pathname;
+      variants.add(normalizeDirectory(absolute));
+    } catch (error) {
+      logger.warn("Не удалось вычислить абсолютный путь для ассетов", error);
+    }
+  }
+
+  for (const variant of variants) {
+    const cleaned = variant.replace(/\\/g, "/");
+    const normalizedVariant = normalizeDirectory(cleaned);
+    if (normalizedVariant) {
+      directories.add(normalizedVariant);
+    }
+
+    const withoutLeadingSlash = cleaned.replace(/^\/+/, "");
+    if (withoutLeadingSlash) {
+      directories.add(normalizeDirectory(withoutLeadingSlash));
+      directories.add(normalizeDirectory(`/${withoutLeadingSlash}`));
+    }
+  }
+
+  const additional = new Set<string>();
+  for (const dir of directories) {
+    const stripped = dir.replace(/^\/+/, "");
+    if (stripped.includes("assets/models/")) {
+      const alternate = stripped.replace("assets/models/", "models/");
+      additional.add(alternate);
+      additional.add(`/${alternate}`);
+    }
+  }
+
+  for (const dir of additional) {
+    const normalizedDir = normalizeDirectory(dir);
+    if (normalizedDir) {
+      directories.add(normalizedDir);
+    }
+  }
+
+  return Array.from(directories);
+}
+
+function normalizeDirectory(directory: string): string {
+  if (!directory) {
+    return "";
+  }
+  let normalized = directory.replace(/\\/g, "/");
+  if (!normalized.endsWith("/")) {
+    normalized += "/";
+  }
+  return normalized;
+}
+
+function createCandidateUrls(directories: string[], baseName: string, extensions: string[]): string[] {
+  const candidates = new Set<string>();
+  const nameVariants = new Set<string>([baseName, baseName.toLowerCase()]);
+  for (const directory of directories) {
+    const dir = normalizeDirectory(directory);
+    for (const name of nameVariants) {
+      for (const ext of extensions) {
+        const variants = [ext, ext.toUpperCase()];
+        for (const variant of variants) {
+          candidates.add(`${dir}${name}${variant}`);
+        }
+      }
+    }
+  }
+  return Array.from(candidates);
+}
+
+async function tryLoadGlbCandidates(scene: Scene, directories: string[], baseName: string): Promise<AssetContainer | null> {
+  const glbCandidates = createCandidateUrls(directories, baseName, [".glb", ".gltf"]);
+  for (const candidate of glbCandidates) {
+    try {
+      const { rootUrl, fileName } = splitUrl(candidate);
+      return await SceneLoader.LoadAssetContainerAsync(rootUrl, fileName, scene);
+    } catch (error) {
+      // continue to next candidate
+    }
+  }
+  return null;
+}
+
+async function tryLoadFbxCandidates(scene: Scene, directories: string[], baseName: string): Promise<AssetContainer | null> {
+  const fbxCandidates = createCandidateUrls(directories, baseName, [".fbx"]);
+  for (const candidate of fbxCandidates) {
+    try {
+      return await loadFBXTemplate(scene, candidate);
+    } catch (error) {
+      // continue to next candidate
+    }
+  }
+  return null;
 }
 
 function createFailedContainer(scene: Scene, descriptor: AssetDescriptor): AssetContainer {

--- a/game/client/src/camera/ThirdPersonCamera.ts
+++ b/game/client/src/camera/ThirdPersonCamera.ts
@@ -27,6 +27,10 @@ export class ThirdPersonCamera {
     this.camera.inputs.clear();
     this.camera.minZ = 0.2;
     this.camera.maxZ = 2000;
+    this.camera.checkCollisions = true;
+    this.camera.applyGravity = false;
+    this.camera.ellipsoid = new Vector3(0.7, 1.4, 0.7);
+    this.camera.ellipsoidOffset = new Vector3(0, 1.2, 0);
     scene.activeCamera = this.camera;
   }
 

--- a/game/client/src/game/PlayerAvatar.ts
+++ b/game/client/src/game/PlayerAvatar.ts
@@ -11,6 +11,7 @@ import {
 import type { AnimationGroup } from "@babylonjs/core";
 import { disposeInstance, instantiateAsset } from "../assets/AssetLoader";
 import { logger } from "../core/Logger";
+import { getWalkableHeight } from "../terrain/terrain";
 
 const PLAYER_ASSET_KEY = "player";
 const RUN_THRESHOLD = 1.2;
@@ -67,6 +68,10 @@ export class PlayerAvatar {
   }
 
   setPosition(position: Vector3): void {
+    const walkableHeight = getWalkableHeight(position.x, position.z);
+    if (!Number.isNaN(walkableHeight)) {
+      position.y = Math.max(position.y, walkableHeight);
+    }
     this.root.position.copyFrom(position);
   }
 

--- a/game/client/src/input/InputComposer.ts
+++ b/game/client/src/input/InputComposer.ts
@@ -2,8 +2,9 @@ import type { NetInputFrame } from "../shared/types";
 import type { IActions, ICharacterController, INetInputSink, InputSettings, MoveCurve } from "./types";
 
 const SEND_RATE = 1 / 15; // 15 Hz snapshots
-const MOVE_SMOOTH = 0.24;
-const LOOK_SMOOTH = 0.18;
+const MOVE_SMOOTH_RATE = 10.5;
+const LOOK_SMOOTH_RATE = 12.5;
+const MAX_FRAME_DT = 1 / 24; // clamp to ~41ms to stay in sync with refresh cycles
 
 export class InputComposer {
   private moveTarget = { x: 0, z: 0 };
@@ -99,23 +100,30 @@ export class InputComposer {
   }
 
   update(dt: number): void {
-    this.accumulator += dt;
+    const clampedDt = Math.min(dt, MAX_FRAME_DT);
+    this.accumulator += clampedDt;
 
     if (this.autoRun) {
       this.moveTarget = { ...this.autoRunVector };
       this.sprintTarget = true;
     }
 
-    this.moveCurrent.x = lerp(this.moveCurrent.x, this.moveTarget.x, MOVE_SMOOTH);
-    this.moveCurrent.z = lerp(this.moveCurrent.z, this.moveTarget.z, MOVE_SMOOTH);
+    const moveBlend = smoothingFactor(MOVE_SMOOTH_RATE, clampedDt);
+    this.moveCurrent.x = lerp(this.moveCurrent.x, this.moveTarget.x, moveBlend);
+    this.moveCurrent.z = lerp(this.moveCurrent.z, this.moveTarget.z, moveBlend);
     if (Math.abs(this.moveCurrent.x) < 0.001) this.moveCurrent.x = 0;
     if (Math.abs(this.moveCurrent.z) < 0.001) this.moveCurrent.z = 0;
 
-    this.sprintCurrent = lerp(this.sprintCurrent ? 1 : 0, this.sprintTarget ? 1 : 0, MOVE_SMOOTH) > 0.5;
+    this.sprintCurrent = lerp(
+      this.sprintCurrent ? 1 : 0,
+      this.sprintTarget ? 1 : 0,
+      moveBlend,
+    ) > 0.5;
 
     if (this.yawPending || this.pitchPending) {
-      const yawStep = this.yawPending * LOOK_SMOOTH;
-      const pitchStep = this.pitchPending * LOOK_SMOOTH;
+      const lookBlend = smoothingFactor(LOOK_SMOOTH_RATE, clampedDt);
+      const yawStep = this.yawPending * lookBlend;
+      const pitchStep = this.pitchPending * lookBlend;
       this.controller.addYaw(yawStep);
       this.controller.addPitch(pitchStep);
       this.yawFrame += yawStep;
@@ -196,6 +204,11 @@ function applyMoveCurve(magnitude: number, curve: MoveCurve): number {
     return Math.pow(magnitude, 0.7);
   }
   return magnitude;
+}
+
+function smoothingFactor(rate: number, dt: number): number {
+  if (dt <= 0) return 0;
+  return 1 - Math.exp(-rate * dt);
 }
 
 function lerp(a: number, b: number, t: number): number {

--- a/game/client/src/main.ts
+++ b/game/client/src/main.ts
@@ -60,8 +60,8 @@ async function bootstrap(): Promise<void> {
           [
             {
               key: "player",
-              type: "max",
-              url: "/assets/models/player.max",
+              type: "gltf",
+              url: "assets/models/player.glb",
             },
           ],
           (progress) => setStageProgress(progress),

--- a/game/client/src/scenes/gameScene.ts
+++ b/game/client/src/scenes/gameScene.ts
@@ -15,6 +15,7 @@ import { sendInput } from "../net/sendInput";
 import { setInventoryVisible } from "../ui/hud";
 import type { RendererHandle } from "../render/initRenderer";
 import { ThirdPersonCamera } from "../camera/ThirdPersonCamera";
+import { createTerrain, getTerrainHeight, getWalkableHeight } from "../terrain/terrain";
 
 type TouchHandle = ReturnType<typeof createTouchInput> | null;
 
@@ -30,11 +31,11 @@ export class GameScene {
   private hasInitialCamera = false;
   private inputHandle: TouchHandle = null;
   private networkReady = false;
-
   constructor(private container: HTMLElement, renderer: RendererHandle) {
     this.renderer = renderer;
     this.scene = new Scene(this.renderer.engine);
     this.scene.clearColor = new Color4(0.05, 0.08, 0.12, 1);
+    this.scene.collisionsEnabled = true;
 
     this.cameraRig = new ThirdPersonCamera(this.scene);
     this.controller = new LocalCharacterController(this.cameraRig);
@@ -42,7 +43,7 @@ export class GameScene {
     this.light = new HemisphericLight("sun", new Vector3(0.3, 1, 0.3), this.scene);
     this.light.intensity = 1.1;
 
-    this.generateTerrain();
+    createTerrain(this.scene);
     this.spawnLandmarks();
   }
 
@@ -74,30 +75,22 @@ export class GameScene {
     this.scene.markAllMaterialsAsDirty(1);
   }
 
-  private generateTerrain(): void {
-    const size = 500;
-    const subdivisions = 80;
-    const ground = MeshBuilder.CreateGround("ground", { width: size, height: size, subdivisions }, this.scene);
-    const data = ground.getVerticesData("position")!;
-    for (let i = 0; i < data.length; i += 3) {
-      const x = data[i];
-      const z = data[i + 2];
-      const height = simplex(x * 0.03, z * 0.03) * 4 + simplex(x * 0.1, z * 0.1) * 1.2;
-      data[i + 1] = height;
-    }
-    ground.updateVerticesData("position", data);
-    ground.convertToFlatShadedMesh();
-    ground.checkCollisions = false;
-  }
-
   private spawnLandmarks(): void {
     for (let i = 0; i < 12; i++) {
       const rock = MeshBuilder.CreateCylinder(`rock_${i}`, { diameter: 6 + Math.random() * 3, height: 4 }, this.scene);
-      rock.position = new Vector3((Math.random() - 0.5) * 400, 2, (Math.random() - 0.5) * 400);
+      const x = (Math.random() - 0.5) * 400;
+      const z = (Math.random() - 0.5) * 400;
+      const groundHeight = getTerrainHeight(x, z);
+      rock.position = new Vector3(x, groundHeight + 2, z);
+      rock.checkCollisions = false;
     }
     for (let i = 0; i < 3; i++) {
       const tower = MeshBuilder.CreateBox(`tower_${i}`, { width: 6, height: 24, depth: 6 }, this.scene);
-      tower.position = new Vector3((Math.random() - 0.5) * 300, 12, (Math.random() - 0.5) * 300);
+      const x = (Math.random() - 0.5) * 300;
+      const z = (Math.random() - 0.5) * 300;
+      const groundHeight = getTerrainHeight(x, z);
+      tower.position = new Vector3(x, groundHeight + 12, z);
+      tower.checkCollisions = false;
     }
   }
 
@@ -149,6 +142,10 @@ export class GameScene {
       const transform = this.world.get(entity, "transform");
       if (!transform) continue;
       const targetPos = new Vector3(transform.position[0], transform.position[1], transform.position[2]);
+      const walkableHeight = getWalkableHeight(targetPos.x, targetPos.z);
+      if (!Number.isNaN(walkableHeight) && (!Number.isFinite(targetPos.y) || targetPos.y < walkableHeight)) {
+        targetPos.y = walkableHeight;
+      }
       if (!this.hasInitialCamera) {
         this.cameraRig.setYaw(transform.rotation[1]);
         this.hasInitialCamera = true;
@@ -169,10 +166,6 @@ export class GameScene {
     this.renderer.stop();
     this.inputHandle?.destroy();
   }
-}
-
-function simplex(x: number, y: number): number {
-  return (Math.sin(x * 1.3 + Math.cos(y * 1.7)) + Math.sin(y * 1.9)) * 0.5;
 }
 
 class LocalCharacterController implements ICharacterController {

--- a/game/client/src/systems/renderSystem.ts
+++ b/game/client/src/systems/renderSystem.ts
@@ -3,6 +3,7 @@ import { Color3, MeshBuilder, StandardMaterial, Vector3 } from "@babylonjs/core"
 import type { World } from "../ecs/world";
 import type { TransformComponent, PlayerComponent, ResourceComponent, AIComponent, HeatComponent } from "../components";
 import { PlayerAvatar } from "../game/PlayerAvatar";
+import { getTerrainHeight, getWalkableHeight } from "../terrain/terrain";
 
 const meshCache = new Map<number, AbstractMesh>();
 const resourceMaterials = new Map<string, StandardMaterial>();
@@ -41,6 +42,10 @@ export function updateRender(scene: Scene, world: World): void {
       }
       visual.avatar.setLocal(player.local);
       tempVec.set(transform.position[0], transform.position[1], transform.position[2]);
+      const targetHeight = getWalkableHeight(tempVec.x, tempVec.z);
+      if (!Number.isNaN(targetHeight) && (!Number.isFinite(tempVec.y) || tempVec.y < targetHeight)) {
+        tempVec.y = targetHeight;
+      }
       visual.avatar.setPosition(tempVec);
       visual.avatar.setRotation(transform.rotation[1]);
       const dt = Math.max(0.016, (now - visual.lastTimestamp) / 1000);
@@ -73,6 +78,10 @@ export function updateRender(scene: Scene, world: World): void {
       meshCache.set(entity, mesh);
     }
     mesh.position = new Vector3(transform.position[0], transform.position[1], transform.position[2]);
+    const groundHeight = getTerrainHeight(mesh.position.x, mesh.position.z);
+    if (!Number.isNaN(groundHeight) && Math.abs(mesh.position.y - groundHeight) < 5) {
+      mesh.position.y = groundHeight;
+    }
     mesh.rotationQuaternion = null;
     mesh.rotation.y = transform.rotation[1];
     const resource = world.get<ResourceComponent>(entity, "resource");

--- a/game/client/src/terrain/terrain.ts
+++ b/game/client/src/terrain/terrain.ts
@@ -1,0 +1,53 @@
+import { Color3, Mesh, MeshBuilder, Scene, StandardMaterial } from "@babylonjs/core";
+
+const TERRAIN_SIZE = 500;
+const TERRAIN_SUBDIVISIONS = 80;
+const BASE_ELEVATION = 0;
+const WALKABLE_OFFSET = 0.92;
+
+export function createTerrain(scene: Scene): Mesh {
+  const ground = MeshBuilder.CreateGround(
+    "ground",
+    { width: TERRAIN_SIZE, height: TERRAIN_SIZE, subdivisions: TERRAIN_SUBDIVISIONS },
+    scene,
+  );
+
+  const positions = ground.getVerticesData("position");
+  if (positions) {
+    for (let i = 0; i < positions.length; i += 3) {
+      const x = positions[i];
+      const z = positions[i + 2];
+      positions[i + 1] = sampleTerrainHeight(x, z);
+    }
+    ground.updateVerticesData("position", positions);
+    ground.convertToFlatShadedMesh();
+  }
+
+  const material = new StandardMaterial("terrain", scene);
+  material.diffuseColor = new Color3(0.36, 0.24, 0.16);
+  material.specularColor = new Color3(0.05, 0.05, 0.05);
+  material.backFaceCulling = true;
+  ground.material = material;
+  ground.receiveShadows = true;
+  ground.checkCollisions = true;
+
+  return ground;
+}
+
+export function getTerrainHeight(x: number, z: number): number {
+  return sampleTerrainHeight(x, z) + BASE_ELEVATION;
+}
+
+export function getWalkableHeight(x: number, z: number): number {
+  return getTerrainHeight(x, z) + WALKABLE_OFFSET;
+}
+
+function sampleTerrainHeight(x: number, z: number): number {
+  const gentle = pseudoSimplex(x * 0.03, z * 0.03) * 4;
+  const detail = pseudoSimplex(x * 0.1, z * 0.1) * 1.2;
+  return gentle + detail;
+}
+
+function pseudoSimplex(x: number, y: number): number {
+  return (Math.sin(x * 1.3 + Math.cos(y * 1.7)) + Math.sin(y * 1.9)) * 0.5;
+}

--- a/game/scripts/generate-player-glb.mjs
+++ b/game/scripts/generate-player-glb.mjs
@@ -1,9 +1,10 @@
-import { writeFileSync, mkdirSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { writeFileSync, mkdirSync, existsSync, cpSync } from "node:fs";
+import { dirname, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const outputPath = resolve(__dirname, "../client/public/assets/models/player.glb");
+const targetDir = resolve(__dirname, "../client/public/assets/models");
+const outputPath = resolve(targetDir, "player.glb");
 
 const COMPONENTS = {
   SCALAR: 1,
@@ -338,11 +339,48 @@ function generate() {
   binHeader.writeUInt32LE(binChunk.length, 0);
   binHeader.writeUInt32LE(0x004e4942, 4);
 
-  const glb = Buffer.concat([header, jsonHeader, jsonChunk, binHeader, binChunk]);
-
-  mkdirSync(dirname(outputPath), { recursive: true });
-  writeFileSync(outputPath, glb);
-  console.log(`player.glb создан (${glb.length} байт)`);
+  return Buffer.concat([header, jsonHeader, jsonChunk, binHeader, binChunk]);
+}
+function syncExternalModels() {
+  mkdirSync(targetDir, { recursive: true });
+  const sources = [
+    resolve(__dirname, "../models"),
+    resolve(__dirname, "../../models"),
+  ];
+  let copied = false;
+  for (const source of sources) {
+    if (!existsSync(source)) {
+      continue;
+    }
+    if (relative(source, targetDir) === "") {
+      continue;
+    }
+    try {
+      cpSync(source, targetDir, { recursive: true, force: true });
+      copied = true;
+      console.log(`Скопированы пользовательские модели из ${relative(process.cwd(), source) || source}`);
+    } catch (error) {
+      console.warn(`Не удалось скопировать модели из ${source}`, error);
+    }
+  }
+  return copied;
 }
 
-generate();
+function main() {
+  const copied = syncExternalModels();
+  if (existsSync(outputPath)) {
+    if (copied) {
+      console.log("Обнаружен пользовательский player.glb, генерация заглушки пропущена");
+    } else {
+      console.log("player.glb уже существует, генерация заглушки не требуется");
+    }
+    return;
+  }
+
+  const glb = generate();
+  mkdirSync(targetDir, { recursive: true });
+  writeFileSync(outputPath, glb);
+  console.log(`Сгенерирован резервный player.glb (${glb.length} байт)`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- generate a collision-enabled brown terrain mesh and expose helpers for sampling ground height to keep landmarks, avatars, and camera positions glued to the surface
- enable collision handling on the third-person camera and align player avatars and entity meshes to walkable terrain heights for believable movement over slopes
- load the player avatar directly from player.glb and make input smoothing time-step aware so camera look updates stay in sync with the refresh rate

## Testing
- ESLINT_USE_FLAT_CONFIG=false npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55403b584832c8a67e8cb71d66029